### PR TITLE
Use modulus operator

### DIFF
--- a/ink/proxy/lib.rs
+++ b/ink/proxy/lib.rs
@@ -207,11 +207,14 @@ mod proxy {
 
 	impl ExchangeRatio {
 		fn exchange_price(&self, expected_acurast_amount: u128) -> u128 {
+			// Calculate the product of numerator and expected_acurast_amount
+			let product = (self.numerator as u128) * expected_acurast_amount;
+
 			// Calculate how many azero is required to cover for the job cost
-			let amount = ((self.numerator as u128) * expected_acurast_amount) / (self.denominator as u128);
+			let amount = product / (self.denominator as u128);
 
 			// If there is a remainder, increment the amount by 1
-			if ((self.numerator as u128) * expected_acurast_amount) % (self.denominator as u128) != 0 {
+			if product % (self.denominator as u128) != 0 {
 				amount + 1
 			} else {
 				amount


### PR DESCRIPTION
Code was performing the multiplication (self.numerator as u128) * expected_acurast_amount twice, once for calculating amount and once for checking if there's a remainder. This is inefficient as it involves duplicate calculations.

The refactored code introduces a new variable product to store the result of the multiplication (self.numerator as u128) * expected_acurast_amount. This way, the multiplication is performed only once, and the result is reused in the calculation of amount and in the check for a remainder.